### PR TITLE
Adding the Cypress screenshots folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 node_modules/
 yarn-error.log
 videos/
+screenshots/
 
 # Other
 .idea/


### PR DESCRIPTION
Cypress running headlessly creates a e2e/videos/ folder and a e2e/screenshots/ folder under ui/tests/, and we didn't have the screenshots/ folder in our .gitignore already.