### PR TITLE
persistedstate now rehydrates certain class objects

### DIFF
--- a/ui/src/components/AccountMenu.vue
+++ b/ui/src/components/AccountMenu.vue
@@ -2,7 +2,7 @@
   <div>
     <v-menu offset-y v-if="isLoggedIn">
       <v-btn id="cur-locale" flat slot="activator">
-        {{ currentAccount.firstName + ' ' + currentAccount.lastName }}
+        {{ currentAccount.fullName() }}
         <v-icon>arrow_drop_down</v-icon>
       </v-btn>
 

--- a/ui/src/models/Account.js
+++ b/ui/src/models/Account.js
@@ -41,4 +41,17 @@ export default class Account {
       this.roles.find(elt => elt === `${ROLE_PREFIX}${role}`)
     );
   }
+
+  /**
+   * Used to convert ordinary object to a class object
+   * after restoring them from localstorage
+   */
+  static fromObject(obj) {
+    return Object.assign(new Account(), {
+      username: obj.username,
+      firstName: obj.firstName,
+      lastName: obj.lastName,
+      roles: obj.roles
+    });
+  }
 }

--- a/ui/src/models/Locale.ts
+++ b/ui/src/models/Locale.ts
@@ -42,7 +42,7 @@ export class Locale {
     return strToRegionalIndicator(this.countryCode.toUpperCase());
   }
 
-  static fromObject(obj) {
+  static fromObject(obj: { languageCode: String; countryCode: String }) {
     return new Locale(`${obj.languageCode}-${obj.countryCode}`);
   }
 }

--- a/ui/src/models/Locale.ts
+++ b/ui/src/models/Locale.ts
@@ -41,6 +41,10 @@ export class Locale {
   get flag() {
     return strToRegionalIndicator(this.countryCode.toUpperCase());
   }
+
+  static fromObject(obj) {
+    return new Locale(`${obj.languageCode}-${obj.countryCode}`);
+  }
 }
 
 export interface I18NValueSchema {

--- a/ui/src/plugins/vuex-persistedstate.js
+++ b/ui/src/plugins/vuex-persistedstate.js
@@ -1,0 +1,55 @@
+import Account from "../models/Account";
+import { Locale } from "../models/Locale.ts";
+import { cloneDeep } from "lodash";
+
+export const objectMap = {
+  Account: Account,
+  Locale: Locale
+};
+
+export const persistedStateOptions = {
+  overwrite: true,
+  getState(key, storage) {
+    let value, states;
+    states =
+      (value = storage.getItem(key)) !== "undefined"
+        ? JSON.parse(value)
+        : undefined;
+    for (let state in states) {
+      let stateValue = states[state];
+      if (Object.hasOwnProperty.call(stateValue, "__class__")) {
+        if (!stateValue.__class__ in objectMap)
+          throw new Error(
+            `class name ${stateValue.__class__} is not in objectMap`
+          );
+        let c = objectMap[stateValue.__class__]; // the class constructor
+        if (!Object.hasOwnProperty.call(c, "fromObject"))
+          throw new Error(
+            `Class with mapped key ${
+              stateValue.__class__
+            } does not have 'fromObject' static method`
+          );
+        delete stateValue.__class__;
+        let classState = c.fromObject(stateValue);
+        states[state] = classState;
+      }
+    }
+    return states;
+  },
+  setState(key, states, storage) {
+    let encodedStates = {};
+    for (let state in states) {
+      let encodedState = cloneDeep(states[state]); // make a copy
+      let c;
+      if (
+        (c = Object.values(objectMap).find(
+          element => states[state] instanceof element
+        ))
+      ) {
+        encodedState.__class__ = c.name; // store the class's name
+      }
+      encodedStates[state] = encodedState;
+    }
+    return storage.setItem(key, JSON.stringify(encodedStates));
+  }
+};

--- a/ui/src/plugins/vuex-persistedstate.js
+++ b/ui/src/plugins/vuex-persistedstate.js
@@ -18,7 +18,7 @@ export const persistedStateOptions = {
     for (let state in states) {
       let stateValue = states[state];
       if (Object.hasOwnProperty.call(stateValue, "__class__")) {
-        if (!stateValue.__class__ in objectMap)
+        if (!(stateValue.__class__ in objectMap))
           throw new Error(
             `class name ${stateValue.__class__} is not in objectMap`
           );

--- a/ui/src/plugins/vuex-persistedstate.js
+++ b/ui/src/plugins/vuex-persistedstate.js
@@ -11,10 +11,8 @@ export const persistedStateOptions = {
   overwrite: true,
   getState(key, storage) {
     let value, states;
-    states =
-      (value = storage.getItem(key)) !== "undefined"
-        ? JSON.parse(value)
-        : undefined;
+    value = storage.getItem(key);
+    states = value ? JSON.parse(value) : undefined;
     for (let state in states) {
       let stateValue = states[state];
       if (Object.hasOwnProperty.call(stateValue, "__class__")) {

--- a/ui/src/plugins/vuex-persistedstate.js
+++ b/ui/src/plugins/vuex-persistedstate.js
@@ -15,7 +15,7 @@ export const persistedStateOptions = {
     states = value ? JSON.parse(value) : undefined;
     for (let state in states) {
       let stateValue = states[state];
-      if (Object.hasOwnProperty.call(stateValue, "__class__")) {
+      if (stateValue && Object.hasOwnProperty.call(stateValue, "__class__")) {
         if (!(stateValue.__class__ in objectMap))
           throw new Error(
             `class name ${stateValue.__class__} is not in objectMap`

--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -282,7 +282,7 @@ const router = new VueRouter({
           ]
         }
       ]
-    },
+    }
   ]
 });
 

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -5,11 +5,12 @@ import Vuex from "vuex";
 import { setJWT } from "./plugins/axios";
 import { Locale, LocaleModel } from "./models/Locale";
 import createPersistedState from "vuex-persistedstate";
+import { persistedStateOptions } from "./plugins/vuex-persistedstate.js";
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
-  plugins: [createPersistedState()],
+  plugins: [createPersistedState(persistedStateOptions)],
 
   state: {
     // Current locale code (e.g., `es-EC`, `en-US`)


### PR DESCRIPTION
- reverted back to use the fullName method in AccountMenu
- added fromObject static method to Account and Locale class for
constructing a class object from ordinary javascript object
- override the default getState and setState functions in persistedstate
plugin to store an additional `__class__` attribute indicating the class
type
- currently uses an 'objectMap' turning class names into actual class