### PR TITLE
Added Links to Course Pages

### DIFF
--- a/ui/src/components/courses/CoursesTable.vue
+++ b/ui/src/components/courses/CoursesTable.vue
@@ -53,7 +53,7 @@
       </v-layout>
     </v-toolbar>
 
-    <!-- Table of existing people -->
+    <!-- Table of existing courses -->
     <v-data-table
       :headers="headers"
       :search="search"
@@ -63,6 +63,7 @@
       :pagination.sync="paginationInfo"
       class="elevation-1"
       data-cy="courses-table"
+      v-on:click:row="goToCourse"
     >
       <v-progress-linear
         slot="progress"
@@ -234,6 +235,13 @@ export default {
   },
 
   methods: {
+    goToCourse(course) {
+      this.$router.push({
+        name: "course-details",
+        params: { courseId: course.id },
+      });
+    },
+
     clickThrough(course) {
       this.$router.push({
         name: "course-details",

--- a/ui/src/components/diplomas/DiplomasTable.vue
+++ b/ui/src/components/diplomas/DiplomasTable.vue
@@ -42,7 +42,7 @@
       </v-layout>
     </v-toolbar>
 
-    <!-- Table of existing people -->
+    <!-- Table of existing diplomas -->
     <v-data-table
       :headers="headers"
       :items="showDiplomas"
@@ -50,6 +50,7 @@
       :search="search"
       class="elevation-1"
       data-cy="diplomas-table"
+      v-on:click:row="goToDiploma"
     >
       <template slot="items" slot-scope="props">
         <tr>
@@ -193,6 +194,13 @@ export default {
   },
 
   methods: {
+    goToDiploma(diploma) {
+      this.$router.push({
+        name: "diploma-details",
+        params: { diplomaId: diploma.id },
+      });
+    },
+
     dispatchAction(actionName, diploma) {
       switch (actionName) {
         case "edit":

--- a/ui/src/components/transcripts/TranscriptsTable.vue
+++ b/ui/src/components/transcripts/TranscriptsTable.vue
@@ -33,7 +33,7 @@
       </v-layout>
     </v-toolbar>
 
-    <!-- Table of existing students -->
+    <!-- Table of existing transcripts -->
     <v-data-table
       :headers="headers"
       :items="showStudents"
@@ -41,6 +41,7 @@
       :search="search"
       class="elevation-1"
       data-cy="transcripts-table"
+      v-on:click:row="goToTranscript"
     >
       <template slot="items" slot-scope="props">
         <tr>
@@ -109,6 +110,13 @@ export default {
     },
   },
   methods: {
+    goToTranscript(transcript) {
+      this.$router.push({
+        name: "transcript-details",
+        params: { studentId: transcript.id },
+      });
+    },
+
     clickThrough(transcript) {
       console.log(transcript);
       this.$router.push({

--- a/ui/src/layouts/NavDrawer.vue
+++ b/ui/src/layouts/NavDrawer.vue
@@ -112,6 +112,10 @@ export default {
               icon: "school",
               children: [
                 {
+                  title: this.$t("courses.course"),
+                  route: "courses",
+                },
+                {
                   title: this.$t("diplomas.diploma"),
                   route: "diplomas-admin",
                 },


### PR DESCRIPTION
#664
Added a link to /courses/all in the NavBar.
The Courses, Diplomas & Transcripts pages now allow you to navigate to the specific pages for each course, diploma & transcript by selecting it on the displayed Table.