### PR TITLE
Ignore Cypress videos

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 screenshots/
+videos/
 dist/
 
 yarn-error.log


### PR DESCRIPTION
'cypress run' creates screenshots and videos of the tests it runs.  We already ignore screenshots, but we should probably also ignore pushing videos of the tests to the repo.