### PR TITLE
Upgraded Button Outlines

### DIFF
--- a/ui/src/components/courses/CourseOffering.vue
+++ b/ui/src/components/courses/CourseOffering.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-btn
-      outline
+      outlined
       color="primary"
       v-on:click="
         $router.push({ name: 'course-details', params: { courseId } })

--- a/ui/src/components/courses/CourseOfferingMeetings.vue
+++ b/ui/src/components/courses/CourseOfferingMeetings.vue
@@ -33,7 +33,7 @@
               <v-btn
                 flat
                 icon
-                outline
+                outlined
                 small
                 color="primary"
                 slot="activator"
@@ -47,7 +47,7 @@
               <v-btn
                 flat
                 icon
-                outline
+                outlined
                 small
                 color="primary"
                 slot="activator"

--- a/ui/src/components/diplomas/DiplomaAdminActions.vue
+++ b/ui/src/components/diplomas/DiplomaAdminActions.vue
@@ -4,7 +4,7 @@
       <v-btn
         text
         icon
-        outline
+        outlined
         color="primary"
         slot="activator"
         v-bind:small="displayContext === 'compact'"
@@ -18,7 +18,7 @@
       <v-btn
         text
         icon
-        outline
+        outlined
         color="primary"
         slot="activator"
         v-bind:small="displayContext === 'compact'"

--- a/ui/src/components/people/AccountForm.vue
+++ b/ui/src/components/people/AccountForm.vue
@@ -79,7 +79,7 @@
       <v-btn
         v-if="person.active && person.accountInfo && account.active"
         color="primary"
-        outline
+        outlined
         v-on:click="deactivateAccount"
         data-cy="deactivate-account"
       >
@@ -88,7 +88,7 @@
       <v-btn
         v-if="person.active && person.accountInfo && !account.active"
         color="primary"
-        outline
+        outlined
         v-on:click="reactivateAccount"
         data-cy="reactivate-account"
       >

--- a/ui/src/components/people/ActionIconButton.vue
+++ b/ui/src/components/people/ActionIconButton.vue
@@ -3,7 +3,7 @@
     <template v-slot:activator="{ on }">
       <v-btn
         icon
-        outline
+        outlined
         small
         color="primary"
         v-on="on"

--- a/ui/src/components/people/RolesTable.vue
+++ b/ui/src/components/people/RolesTable.vue
@@ -62,7 +62,7 @@
           <v-tooltip bottom>
             <v-btn
               icon
-              outline
+              outlined
               small
               color="primary"
               slot="activator"

--- a/ui/src/components/places/AreaTable.vue
+++ b/ui/src/components/places/AreaTable.vue
@@ -53,7 +53,7 @@
         <v-tooltip bottom>
           <v-btn
             icon
-            outline
+            outlined
             small
             color="primary"
             slot="activator"
@@ -68,7 +68,7 @@
         <v-tooltip bottom>
           <v-btn
             icon
-            outline
+            outlined
             small
             color="primary"
             slot="activator"
@@ -84,7 +84,7 @@
           <v-btn
             v-if="props.item.active === true"
             icon
-            outline
+            outlined
             small
             color="primary"
             slot="activator"
@@ -99,7 +99,7 @@
           <v-btn
             v-if="props.item.active === false"
             icon
-            outline
+            outlined
             small
             color="primary"
             slot="activator"

--- a/ui/src/components/transcripts/AddDiplomaEditor.vue
+++ b/ui/src/components/transcripts/AddDiplomaEditor.vue
@@ -13,7 +13,7 @@
               v-model="diploma.id"
               :items="items"
               v-bind:label="$t('diplomas.diploma')"
-              outline
+              outlined
               item-value="id"
               item-text="name"
               :success="valid"


### PR DESCRIPTION
Buttons use a "outline" phrase inside the tag to indicate the button should be outlined in color, not filled. However, Vue changed the name from "outline" to "outlined." I went through every file in ui/src/components and made the appropriate change.