### PR TITLE
Refactor EventDetails Components

### DIFF
--- a/ui/src/components/events/EventAssetDetails.vue
+++ b/ui/src/components/events/EventAssetDetails.vue
@@ -17,12 +17,12 @@
             </v-btn>
           </v-layout>
         </v-container>
-        <v-list v-if="assetList.length">
-          <template v-for="asset in assetList">
+        <v-list v-if="assets.length">
+          <template v-for="asset in assets">
             <v-divider v-bind:key="'assetDivider' + asset.id"></v-divider>
             <v-list-item v-bind:key="asset.id">
               <v-list-item-content>
-                <v-container fluid class="pa-0">
+                <v-container fluid>
                   <v-layout row justify-space-between align-center>
                     <v-flex>{{ asset.description }}</v-flex>
                     <v-flex shrink>
@@ -66,7 +66,7 @@
           <entity-search
             data-cy="asset-entity-search"
             v-model="addAssetDialog.asset"
-            :existing-entities="assetList"
+            :existing-entities="assets"
             asset
           ></entity-search>
         </v-card-text>
@@ -142,8 +142,6 @@ export default {
 
   data() {
     return {
-      assetList: [],
-
       addAssetDialog: {
         show: false,
         loading: false,
@@ -158,12 +156,6 @@ export default {
     };
   },
 
-  watch: {
-    assets(val) {
-      this.assetList = val;
-    },
-  },
-
   methods: {
     closeAddAssetDialog() {
       this.addAssetDialog.loading = false;
@@ -172,55 +164,21 @@ export default {
     },
 
     addAsset() {
-      const eventId = this.$route.params.event;
-      let assetId = this.addAssetDialog.asset.id;
-      const idx = this.assetList.findIndex((a) => a.id === assetId);
+      // Emit asset-added event
       this.addAssetDialog.loading = true;
-      if (idx > -1) {
-        this.closeAddAssetDialog();
-        this.showSnackbar(this.$t("assets.asset-on-event"));
-        return;
-      }
-
-      this.$http
-        .post(`/api/v1/events/${eventId}/assets/${assetId}`)
-        .then(() => {
-          this.showSnackbar(this.$t("assets.asset-added"));
-          console.log(this.addAssetDialog.asset);
-          this.$emit("asset-added", this.addAssetDialog.asset);
-          this.closeAddAssetDialog();
-        })
-        .catch((err) => {
-          console.log(err);
-          this.addAssetDialog.loading = false;
-          if (err.response.status === 422) {
-            this.showSnackbar(this.$t("assets.error-asset-assigned"));
-          } else {
-            this.showSnackbar(this.$t("assets.error-adding-asset"));
-          }
-        });
+      this.$emit("asset-added", { asset: this.addAssetDialog.asset });
+      this.closeAddAssetDialog();
+      this.addAssetDialog.loading = false;
     },
 
     deleteAsset() {
-      let id = this.deleteAssetDialog.assetId;
-      const idx = this.assetList.findIndex((a) => a.id === id);
+      let id =  this.deleteAssetDialog.assetId;
       this.deleteAssetDialog.loading = true;
-      const eventId = this.$route.params.event;
-      this.$http
-        .delete(`/api/v1/events/${eventId}/assets/${id}`)
-        .then((resp) => {
-          console.log("REMOVED", resp);
-          this.deleteAssetDialog.show = false;
-          this.deleteAssetDialog.loading = false;
-          this.deleteAssetDialog.assetId = -1;
-          this.assetList.splice(idx, 1); //TODO maybe fix me?
-          this.showSnackbar(this.$t("assets.asset-removed"));
-        })
-        .catch((err) => {
-          console.log(err);
-          this.deleteAssetDialog.loading = false;
-          this.showSnackbar(this.$t("assets.error-removing-asset"));
-        });
+      // Emit asset-deleted event
+      this.$emit("asset-deleted", { assetId: id });
+      this.deleteAssetDialog.show = false;
+      this.deleteAssetDialog.loading = false;
+      this.deleteAssetDialog.assetId = -1;
     },
 
     showDeleteAssetDialog(assetId) {

--- a/ui/src/components/events/EventDetails.vue
+++ b/ui/src/components/events/EventDetails.vue
@@ -133,7 +133,7 @@
               :groups="event.groups"
               :loaded="groupsLoaded"
               v-on:snackbar="showSnackbar($event)"
-              v-on:group-added="reloadGroups"
+              v-on:group-added="addGroup"
             ></event-group-details>
           </v-flex>
         </v-layout>
@@ -263,6 +263,7 @@ export default {
   },
 
   methods: {
+
     getEvent() {
       const id = this.$route.params.event;
       return this.$http
@@ -340,6 +341,37 @@ export default {
       this.groupsLoaded = false;
       this.event.groups.push(data);
       this.groupsLoaded = true;
+    },
+
+    addGroup(data) {
+      console.log("check");
+      console.log(data.group);
+      const eventId = this.$route.params.event;
+      let groupId = data.group.id;
+      const idx = this.event.groups.findIndex((t) => t.id === groupId);
+      if (idx > -1) {
+        this.showSnackbar(this.$t("groups-group-on-event"));
+        return;
+      }
+
+      this.$http
+        .post(`/api/v1/events/${eventId}/groups/${groupId}`)
+        .then(() => {
+          this.showSnackbar(this.$t("groups.group-added"));
+          console.log("A----------------------------------------------------");
+          console.log(data.group);
+          this.event.groups.push(data.group);
+        })
+        .catch((err) => {
+          console.log(err);
+          if (err.response.status === 422) {
+            this.showSnackbar(this.$t("groups.error-group-assigned"));
+          } else {
+            this.showSnackbar(this.$t("groups.error-adding-group"));
+          }
+        });
+      console.log("just checking:");
+      console.log(data.group);
     },
 
     editEvent(event) {

--- a/ui/src/components/events/EventDetails.vue
+++ b/ui/src/components/events/EventDetails.vue
@@ -2,7 +2,7 @@
   <v-layout column>
     <v-layout row wrap>
       <v-flex xs12>
-        <v-card class="ma-1">
+        <v-card>
           <template v-if="eventLoaded">
             <v-container fill-height fluid>
               <v-flex xs9 sm9 align-end flexbox>
@@ -105,7 +105,8 @@
               :teams="event.teams"
               :loaded="teamsLoaded"
               v-on:snackbar="showSnackbar($event)"
-              v-on:team-added="reloadTeams"
+              v-on:team-added="addTeam"
+              v-on:team-deleted="deleteTeam"
             ></event-team-details>
           </v-flex>
           <v-flex>
@@ -113,7 +114,8 @@
               :persons="event.persons"
               :loaded="personsLoaded"
               v-on:snackbar="showSnackbar($event)"
-              v-on:person-added="reloadPersons"
+              v-on:person-added="addPerson"
+              v-on:person-deleted="deletePerson"
             ></event-person-details>
           </v-flex>
         </v-layout>
@@ -125,7 +127,8 @@
               :assets="event.assets"
               :loaded="assetsLoaded"
               v-on:snackbar="showSnackbar($event)"
-              v-on:asset-added="reloadAssets"
+              v-on:asset-added="addAsset"
+              v-on:asset-deleted="deleteAsset"
             ></event-asset-details>
           </v-flex>
           <v-flex>
@@ -134,6 +137,7 @@
               :loaded="groupsLoaded"
               v-on:snackbar="showSnackbar($event)"
               v-on:group-added="addGroup"
+              v-on:group-deleted="deleteGroup"
             ></event-group-details>
           </v-flex>
         </v-layout>
@@ -283,7 +287,7 @@ export default {
             : this.event.groups
                 .filter(function (g) {
                   // make sure the group is active
-                  // and the group has an active relationship to the event
+                  // ateamListnd the group has an active relationship to the event
                   if (g.group) {
                     return g.active && g.group.active;
                   }
@@ -299,53 +303,153 @@ export default {
         });
     },
 
-    reloadTeams(data) {
-      this.teamsLoaded = false;
-      let active = data.active;
-      let description = data.description;
-      let id = data.id;
-      let t = { active, description, id };
-      this.event.teams.push(t);
-      this.teamsLoaded = true;
+    addTeam(data) {
+      const eventId = this.$route.params.event;
+      let teamId = data.team.id;
+      const idx = this.event.teams.findIndex((t) => t.id === teamId);
+      if (idx > -1) {
+        this.showSnackbar(this.$t("teams.team-on-event"));
+        return;
+      }
+
+      this.$http
+        .post(`/api/v1/events/${eventId}/teams/${teamId}`)
+        .then(() => {
+          this.showSnackbar(this.$t("teams.team-added"));
+          this.event.teams.push(data.team);
+        })
+        .catch((err) => {
+          console.log(err);
+          if (err.response.status === 422) {
+            this.showSnackbar(this.$t("teams.error-team-assigned"));
+          } else {
+            this.showSnackbar(this.$t("teams.error-adding-team"));
+          }
+        });
     },
 
-    reloadAssets(data) {
-      this.assetsLoaded = false;
-
-      let active = data.active;
-      let description = data.description;
-      let id = data.id;
-      let location_id = data.location_id;
-      let a = { active, description, id, location_id };
-      this.event.assets.push(a);
-      this.assetsLoaded = true;
-    },
-    //add data back here maybe if you want to try again
-    reloadPersons(personData, desData) {
-      this.personsLoaded = false;
-
-      let event_id = parseInt(this.$route.params.event);
-      let person = personData;
-      let description = desData;
-      let id = person.id;
-      let person_id = person.id;
-      let p = { person, description, id, person_id, event_id };
-      this.event.persons.push(p);
-      this.event.persons = !this.event.persons
-        ? []
-        : this.event.persons.map((p) => Object.assign(p, { id: p.person_id }));
-      this.personsLoaded = true;
+    deleteTeam(data) {
+      const eventId = this.$route.params.event;
+      let id = data.teamId;
+      const idx = this.event.teams.findIndex((t) => t.id === id);
+      this.$http
+        .delete(`/api/v1/events/${eventId}/teams/${id}`)
+        .then((resp) => {
+          console.log("REMOVED", resp);
+          this.event.teams.splice(idx, 1); //TODO maybe fix me?
+          this.showSnackbar(this.$t("teams.team-removed"));
+        })
+        .catch((err) => {
+          console.log(err);
+          this.showSnackbar(this.$t("teams.error-removing-team"));
+        });
     },
 
-    reloadGroups(data) {
-      this.groupsLoaded = false;
-      this.event.groups.push(data);
-      this.groupsLoaded = true;
+    addPerson(data) {
+      const eventId = this.$route.params.event;
+      let personData = data.person;
+      let personId = personData.id;
+      if (!data.editMode) {
+        const idx = this.event.persons.findIndex((p) => p.id === personId);
+        if (idx > -1) {
+          this.showSnackbar(this.$t("events.persons.person-on-event"));
+        }
+      }
+      let body = { description: data.description };
+      let promise;
+      if (data.editMode) {
+        promise = this.$http.patch(
+          `/api/v1/events/${eventId}/individuals/${personId}`,
+          body
+        );
+      } else {
+        promise = this.$http.post(
+          `/api/v1/events/${eventId}/individuals/${personId}`,
+          body
+        );
+      }
+      promise
+        .then(() => {
+          if (data.editMode) {
+            this.showSnackbar(this.$t("events.persons.person-edited"));
+          } else {
+            this.showSnackbar(this.$t("events.persons.person-added"));
+          }
+          if (!data.editMode) {
+            let eventPerson = {id: personId, person_id: personId, event_id: eventId, person: personData, description: data.description };
+            this.event.persons.push(eventPerson);
+          }
+      })
+      .catch((err) => {
+        console.log(err);
+        if (err.response.status === 422) {
+          this.showSnackbar(this.$t("events.persons.error-person-assigned"));
+        } else {
+          this.showSnackbar(this.$t("events.persons.error-adding-person"));
+        }
+      });
+    },
+
+    deletePerson(data) {
+        const eventId = this.$route.params.event;
+        let id = data.personId;
+        const idx = this.event.persons.findIndex((p) => p.id === id)
+        this.$http
+        .delete(`/api/v1/events/${eventId}/individuals/${id}`)
+        .then((resp) => {
+          console.log("REMOVED", resp);
+          this.event.persons.splice(idx, 1); //TODO maybe fix me?
+          this.showSnackbar(this.$t("events.persons.person-removed"));
+        })
+        .catch((err) => {
+          console.log(err);
+          this.showSnackbar(this.$t("events.persons.error-removing-person"));
+        });
+    },
+
+    addAsset(data) {
+      const eventId = this.$route.params.event;
+      let assetId = data.asset.id;
+      const idx = this.event.assets.findIndex((t) => t.id === assetId);
+      if (idx > -1) {
+        this.showSnackbar(this.$t("assets.asset-on-event"));
+        return;
+      }
+
+      this.$http
+        .post(`/api/v1/events/${eventId}/assets/${assetId}`)
+        .then(() => {
+          this.showSnackbar(this.$t("assets.asset-added"));
+          this.event.assets.push(data.asset);
+        })
+        .catch((err) => {
+          console.log(err);
+          if (err.response.status === 422) {
+            this.showSnackbar(this.$t("assets.error-asset-assigned"));
+          } else {
+            this.showSnackbar(this.$t("assets.error-adding-asset"));
+          }
+        });
+    },
+
+    deleteAsset(data) {
+      const eventId = this.$route.params.event;
+      let id = data.assetId;
+      const idx = this.event.teams.findIndex((a) => a.id === id);
+      this.$http
+        .delete(`/api/v1/events/${eventId}/assets/${id}`)
+        .then((resp) => {
+          console.log("REMOVED", resp);
+          this.event.assets.splice(idx, 1); //TODO maybe fix me?
+          this.showSnackbar(this.$t("assets.asset-removed"));
+        })
+        .catch((err) => {
+          console.log(err);
+          this.showSnackbar(this.$t("assets.error-removing-asset"));
+        });
     },
 
     addGroup(data) {
-      console.log("check");
-      console.log(data.group);
       const eventId = this.$route.params.event;
       let groupId = data.group.id;
       const idx = this.event.groups.findIndex((t) => t.id === groupId);
@@ -358,8 +462,6 @@ export default {
         .post(`/api/v1/events/${eventId}/groups/${groupId}`)
         .then(() => {
           this.showSnackbar(this.$t("groups.group-added"));
-          console.log("A----------------------------------------------------");
-          console.log(data.group);
           this.event.groups.push(data.group);
         })
         .catch((err) => {
@@ -370,8 +472,23 @@ export default {
             this.showSnackbar(this.$t("groups.error-adding-group"));
           }
         });
-      console.log("just checking:");
-      console.log(data.group);
+    },
+
+    deleteGroup(data) {
+      const eventId = this.$route.params.event;
+      let id = data.groupId;
+      const idx = this.event.groups.findIndex((t) => t.id === id);
+      this.$http
+        .delete(`/api/v1/events/${eventId}/groups/${id}`)
+        .then((resp) => {
+          console.log("REMOVED", resp);
+          this.event.groups.splice(idx, 1); //TODO maybe fix me?
+          this.showSnackbar(this.$t("groups.group-removed"));
+        })
+        .catch((err) => {
+          console.log(err);
+          this.showSnackbar(this.$t("groups.error-removing-group"));
+        });
     },
 
     editEvent(event) {

--- a/ui/src/components/events/EventGroupDetails.vue
+++ b/ui/src/components/events/EventGroupDetails.vue
@@ -187,6 +187,7 @@ export default {
     },
 
     addGroup() {
+      /*
       const eventId = this.$route.params.event;
       let groupId = this.addGroupDialog.group.id;
       const idx = this.groupList.findIndex((t) => t.id === groupId);
@@ -213,6 +214,13 @@ export default {
             this.showSnackbar(this.$t("groups.error-adding-group"));
           }
         });
+        */
+      // Emit group-added event
+      this.addGroupDialog.loading = true;
+      //const newData = this.addGroupDialog;
+      this.$emit("group-added", { group: this.addGroupDialog.group });
+      this.addGroupDialog.loading = false;
+      this.closeAddGroupDialog();
     },
 
     deleteGroup() {

--- a/ui/src/components/events/EventGroupDetails.vue
+++ b/ui/src/components/events/EventGroupDetails.vue
@@ -17,8 +17,8 @@
             </v-btn>
           </v-layout>
         </v-container>
-        <v-list v-if="groupList.length">
-          <template v-for="group in groupList">
+        <v-list v-if="groups.length">
+          <template v-for="group in groups">
             <v-divider v-bind:key="'groupDivider' + group.id"></v-divider>
             <v-list-item v-bind:key="group.id">
               <v-list-item-content class="pr-0">
@@ -81,7 +81,7 @@
           <entity-search
             data-cy="group-entity-search"
             v-model="addGroupDialog.group"
-            :existing-entities="groupList"
+            :existing-entities="groups"
             group
           ></entity-search>
         </v-card-text>
@@ -157,8 +157,6 @@ export default {
 
   data() {
     return {
-      groupList: [],
-
       addGroupDialog: {
         show: false,
         loading: false,
@@ -173,12 +171,6 @@ export default {
     };
   },
 
-  watch: {
-    groups(val) {
-      this.groupList = val;
-    }
-  },
-
   methods: {
     closeAddGroupDialog() {
       this.addGroupDialog.loading = false;
@@ -187,62 +179,21 @@ export default {
     },
 
     addGroup() {
-      /*
-      const eventId = this.$route.params.event;
-      let groupId = this.addGroupDialog.group.id;
-      const idx = this.groupList.findIndex((t) => t.id === groupId);
-      this.addGroupDialog.loading = true;
-      if (idx > -1) {
-        this.closeAddGroupDialog();
-        this.showSnackbar(this.$t("groups.group-on-event"));
-        return;
-      }
-
-      this.$http
-        .post(`/api/v1/events/${eventId}/groups/${groupId}`)
-        .then(() => {
-          this.showSnackbar(this.$t("groups.group-added"));
-          this.$emit("group-added", this.addGroupDialog.group);
-          this.closeAddGroupDialog();
-        })
-        .catch((err) => {
-          console.log(err);
-          this.addGroupDialog.loading = false;
-          if (err.response.status === 422) {
-            this.showSnackbar(this.$t("groups.error-group-assigned"));
-          } else {
-            this.showSnackbar(this.$t("groups.error-adding-group"));
-          }
-        });
-        */
       // Emit group-added event
       this.addGroupDialog.loading = true;
-      //const newData = this.addGroupDialog;
       this.$emit("group-added", { group: this.addGroupDialog.group });
-      this.addGroupDialog.loading = false;
       this.closeAddGroupDialog();
+      this.addGroupDialog.loading = false;
     },
 
     deleteGroup() {
-      let id = this.deleteGroupDialog.groupId;
-      const idx = this.groupList.findIndex((t) => t.id === id);
-      this.deleteGroupDialog.loading = true;
-      const eventId = this.$route.params.event;
-      this.$http
-        .delete(`/api/v1/events/${eventId}/groups/${id}`)
-        .then((resp) => {
-          console.log("REMOVED", resp);
-          this.deleteGroupDialog.show = false;
-          this.deleteGroupDialog.loading = false;
-          this.deleteGroupDialog.groupId = -1;
-          this.groupList.splice(idx, 1); //TODO maybe fix me?
-          this.showSnackbar(this.$t("groups.group-removed"));
-        })
-        .catch((err) => {
-          console.log(err);
-          this.deleteGroupDialog.loading = false;
-          this.showSnackbar(this.$t("groups.error-removing-group"));
-        });
+     let id = this.deleteGroupDialog.groupId;
+     this.deleteGroupDialog.loading = true;
+     // Emit group-deleted event
+     this.$emit("group-deleted", { groupId: id });
+     this.deleteGroupDialog.show = false;
+     this.deleteGroupDialog.loading = false;
+     this.deleteGroupDialog.groupId = -1;
     },
 
     showDeleteGroupDialog(groupId) {

--- a/ui/src/components/events/EventPersonDetails.vue
+++ b/ui/src/components/events/EventPersonDetails.vue
@@ -17,12 +17,12 @@
             </v-btn>
           </v-layout>
         </v-container>
-        <v-list v-if="personList.length">
-          <template v-for="person in personList">
+        <v-list v-if="persons.length">
+          <template v-for="person in persons">
             <v-divider v-bind:key="'personDivider' + person.id"></v-divider>
             <v-list-item v-bind:key="person.id">
               <v-list-item-content>
-                <v-container fluid class="pa-0">
+                <v-container fluid>
                   <v-layout align-center row justify-space-between>
                     <v-flex>
                       {{ getFullName(person.person) }}
@@ -102,7 +102,7 @@
               person
               data-cy="person-entity-search"
               v-model="addPersonDialog.person"
-              :existing-entities="personList"
+              :existing-entities="persons"
             ></entity-search>
             <v-btn
               class="mr-0 ml-0"
@@ -197,8 +197,6 @@ export default {
 
   data() {
     return {
-      personList: [],
-
       addPersonDialog: {
         editMode: false,
         show: false,
@@ -229,12 +227,6 @@ export default {
       data: {},
       translations: {},
     };
-  },
-
-  watch: {
-    persons(val) {
-      this.personList = val;
-    },
   },
 
   computed: {
@@ -275,78 +267,25 @@ export default {
     },
 
     addPerson() {
-      console.log("this.persons: " + this.persons);
-      const eventId = this.$route.params.event;
-      let personId = this.addPersonDialog.person.id;
-      //console.log(this.addPersonDialog.person);
       this.addPersonDialog.loading = true;
-      if (!this.addPersonDialog.editMode) {
-        const idx = this.personList.findIndex((p) => p.id === personId);
-        if (idx > -1) {
-          this.closeAddPersonDialog();
-          this.showSnackbar(this.$t("events.persons.person-on-event"));
-          return;
-        }
-      }
-      let body = { description: this.addPersonDialog.description };
-      let promise;
-      if (this.addPersonDialog.editMode) {
-        promise = this.$http.patch(
-          `/api/v1/events/${eventId}/individuals/${personId}`,
-          body
-        );
-      } else {
-        promise = this.$http.post(
-          `/api/v1/events/${eventId}/individuals/${personId}`,
-          body
-        );
-      }
-      promise
-        .then(() => {
-          //console.log(this.addPersonDialog.person);
-          if (this.addPersonDialog.editMode) {
-            this.showSnackbar(this.$t("events.persons.person-edited"));
-          } else {
-            this.showSnackbar(this.$t("events.persons.person-added"));
-          }
-          this.$emit(
-            "person-added",
-            this.addPersonDialog.person,
-            this.addPersonDialog.description
-          );
-          this.closeAddPersonDialog();
-        })
-        .catch((err) => {
-          console.log(err);
-          this.addPersonDialog.loading = false;
-          if (err.response.status === 422) {
-            this.showSnackbar(this.$t("events.persons.error-person-assigned"));
-          } else {
-            this.showSnackbar(this.$t("events.persons.error-adding-person"));
-          }
-        });
+      let newData = {
+        person: this.addPersonDialog.person,
+        editMode: this.addPersonDialog.editMode,
+        description: this.addPersonDialog.description,
+      };
+      // Emit person-added event
+      this.$emit("person-added", newData);
+      this.closeAddPersonDialog();
     },
 
     deletePerson() {
       let id = this.deletePersonDialog.personId;
-      const idx = this.personList.findIndex((p) => p.id === id);
       this.deletePersonDialog.loading = true;
-      const eventId = this.$route.params.event;
-      this.$http
-        .delete(`/api/v1/events/${eventId}/individuals/${id}`)
-        .then((resp) => {
-          console.log("REMOVED", resp);
-          this.deletePersonDialog.show = false;
-          this.deletePersonDialog.loading = false;
-          this.deletePersonDialog.personId = -1;
-          this.personList.splice(idx, 1); //TODO maybe fix me?
-          this.showSnackbar(this.$t("events.persons.person-removed"));
-        })
-        .catch((err) => {
-          console.log(err);
-          this.deletePersonDialog.loading = false;
-          this.showSnackbar(this.$t("events.persons.error-removing-person"));
-        });
+      // Emit person-deleted event
+      this.$emit("person-deleted", { personId: id });
+      this.deletePersonDialog.show = false;
+      this.deletePersonDialog.loading = false;
+      this.deletePersonDialog.personId = -1;
     },
 
     showDeletePersonDialog(personId) {
@@ -359,7 +298,6 @@ export default {
     },
 
     getFullName(person) {
-      //console.log("fullname call: "+person.firstName);
       return `${person.firstName} ${person.lastName}`;
     },
   },

--- a/ui/src/components/events/EventTeamDetails.vue
+++ b/ui/src/components/events/EventTeamDetails.vue
@@ -17,8 +17,8 @@
             </v-btn>
           </v-layout>
         </v-container>
-        <v-list v-if="teamList.length">
-          <template v-for="team in teamList">
+        <v-list v-if="teams.length">
+          <template v-for="team in teams">
             <v-divider v-bind:key="'teamDivider' + team.id"></v-divider>
             <v-list-item v-bind:key="team.id">
               <v-list-item-content class="pr-0">
@@ -81,7 +81,7 @@
           <entity-search
             data-cy="team-entity-search"
             v-model="addTeamDialog.team"
-            :existing-entities="teamList"
+            :existing-entities="teams"
             team
           ></entity-search>
         </v-card-text>
@@ -157,8 +157,6 @@ export default {
 
   data() {
     return {
-      teamList: [],
-
       addTeamDialog: {
         show: false,
         loading: false,
@@ -173,12 +171,6 @@ export default {
     };
   },
 
-  watch: {
-    teams(val) {
-      this.teamList = val;
-    },
-  },
-
   methods: {
     closeAddTeamDialog() {
       this.addTeamDialog.loading = false;
@@ -187,54 +179,21 @@ export default {
     },
 
     addTeam() {
-      const eventId = this.$route.params.event;
-      let teamId = this.addTeamDialog.team.id;
-      const idx = this.teamList.findIndex((t) => t.id === teamId);
-      this.addTeamDialog.loading = true;
-      if (idx > -1) {
-        this.closeAddTeamDialog();
-        this.showSnackbar(this.$t("teams.team-on-event"));
-        return;
-      }
-
-      this.$http
-        .post(`/api/v1/events/${eventId}/teams/${teamId}`)
-        .then(() => {
-          this.showSnackbar(this.$t("teams.team-added"));
-          this.$emit("team-added", this.addTeamDialog.team);
-          this.closeAddTeamDialog();
-        })
-        .catch((err) => {
-          console.log(err);
-          this.addTeamDialog.loading = false;
-          if (err.response.status === 422) {
-            this.showSnackbar(this.$t("teams.error-team-assigned"));
-          } else {
-            this.showSnackbar(this.$t("teams.error-adding-team"));
-          }
-        });
+       this.addTeamDialog.loading = true;
+       // Emit team-added event
+       this.$emit("team-added", { team: this.addTeamDialog.team });
+       this.closeAddTeamDialog();
+       
     },
 
     deleteTeam() {
       let id = this.deleteTeamDialog.teamId;
-      const idx = this.teamList.findIndex((t) => t.id === id);
       this.deleteTeamDialog.loading = true;
-      const eventId = this.$route.params.event;
-      this.$http
-        .delete(`/api/v1/events/${eventId}/teams/${id}`)
-        .then((resp) => {
-          console.log("REMOVED", resp);
-          this.deleteTeamDialog.show = false;
-          this.deleteTeamDialog.loading = false;
-          this.deleteTeamDialog.teamId = -1;
-          this.teamList.splice(idx, 1); //TODO maybe fix me?
-          this.showSnackbar(this.$t("teams.team-removed"));
-        })
-        .catch((err) => {
-          console.log(err);
-          this.deleteTeamDialog.loading = false;
-          this.showSnackbar(this.$t("teams.error-removing-team"));
-        });
+      // Emit team-deleted event
+      this.$emit("team-deleted", { teamId: id });
+      this.deleteTeamDialog.show = false;
+      this.deleteTeamDialog.loading = false;
+      this.deleteTeamDialog.groupId = -1;
     },
 
     showDeleteTeamDialog(teamId) {


### PR DESCRIPTION
Implemented a cleaner fix for issue #677. Refactored the child components in `EventDetails.vue` to no longer modify their own props; as a result, all database changes are handled by the parent `EventDetails.vue` component.
Also removed `class` tags in a couple elements to make the components actually readable - I may go back and significantly clean up the formatting at a later point