### PR TITLE
Fixed broken navbar and public events page

### DIFF
--- a/ui/src/layouts/NavItem.vue
+++ b/ui/src/layouts/NavItem.vue
@@ -2,13 +2,17 @@
   <div>
     <!-- Interior node -->
     <v-list-group v-if="isInterior">
-      <template v-slot:activator="{ on }">
-        <v-btn v-on="on">
+      <!--
+        Slot syntax in vue is a little confusing. In this instance,
+        the <v-list-group> component from Vuetify has a built-in activator
+        slot that enables an expansion list. Read more here:
+        https://vuetifyjs.com/en/components/lists/#slots
+      -->
+      <template v-slot:activator>
           <v-list-item-icon>
             <v-icon>{{ item.icon }}</v-icon>
           </v-list-item-icon>
           <v-list-item-title>{{ item.title }}</v-list-item-title>
-        </v-btn>
       </template>
 
       <nav-item

--- a/ui/src/pages/public/Events.vue
+++ b/ui/src/pages/public/Events.vue
@@ -22,14 +22,13 @@
           data-cy="start-date-picker"
         >
           <template v-slot:activator="{ on }">
-            <v-btn v-on="on">
-              <v-text-field
-                v-model="filterStart"
-                v-bind:label="$t('events.start-date')"
-                prepend-icon="event"
-                readonly
-              />
-            </v-btn>
+            <v-text-field
+              v-on="on"
+              v-model="filterStart"
+              v-bind:label="$t('events.start-date')"
+              prepend-icon="event"
+              readonly
+            ></v-text-field>
           </template>
           <v-date-picker
             v-model="filterStart"
@@ -53,14 +52,13 @@
           data-cy="end-date-picker"
         >
           <template v-slot:activator="{ on }">
-            <v-btn v-on="on">
-              <v-text-field
-                v-model="filterEnd"
-                v-bind:label="$t('events.end-date')"
-                prepend-icon="event"
-                readonly
-              />
-            </v-btn>
+            <v-text-field
+              v-on="on"
+              v-model="filterEnd"
+              v-bind:label="$t('events.end-date')"
+              prepend-icon="event"
+              readonly
+            />
           </template>
           <v-date-picker
             v-model="filterEnd"


### PR DESCRIPTION
- Fixed an issue in `NavItem.vue` where an Interior node would not properly display its content
- Fixed an issue in `/pages/public/Events.vue` where the date range pickers were either not showing up or not utilizing slots properly