### PR TITLE
Updated address add

### DIFF
--- a/api/src/people/api.py
+++ b/api/src/people/api.py
@@ -114,7 +114,7 @@ def read_one_person(person_id):
     return jsonify(person_schema.dump(result))
 
 
-@people.route('/persons/<person_id>', methods=['PATCH'])
+@people.route('/persons/<person_id>', methods=['PATCH', 'PUT'])
 @jwt_required
 def update_person(person_id):
     try:

--- a/api/src/people/models.py
+++ b/api/src/people/models.py
@@ -126,6 +126,7 @@ class PersonSchema(Schema):
 
     active = fields.Boolean(required=True)
     address_id = fields.Integer(data_key='addressId', allow_none=True)
+    #address = fields.Nested('AddressSchema', dump_only=True)
 
     attributesInfo = fields.Nested('PersonAttributeSchema', many=True)
     images = fields.Nested('ImagePersonSchema', many=True, exclude=['person'], dump_only=True)

--- a/api/src/people/models.py
+++ b/api/src/people/models.py
@@ -126,7 +126,7 @@ class PersonSchema(Schema):
 
     active = fields.Boolean(required=True)
     address_id = fields.Integer(data_key='addressId', allow_none=True)
-    #address = fields.Nested('AddressSchema', dump_only=True)
+    address = fields.Nested('AddressSchema', dump_only=True)
 
     attributesInfo = fields.Nested('PersonAttributeSchema', many=True)
     images = fields.Nested('ImagePersonSchema', many=True, exclude=['person'], dump_only=True)

--- a/ui/src/components/AddressForm.vue
+++ b/ui/src/components/AddressForm.vue
@@ -182,6 +182,8 @@ export default {
               } else {
                 this.addressErr = false;
                 let addr = response.results[0];
+                console.log("addr");
+                console.log(response);
                 this.address.address = addr.formatted_address;
                 this.address.latitude = addr.geometry.location.lat;
                 this.address.longitude = addr.geometry.location.lng;

--- a/ui/src/components/assets/AssetForm.vue
+++ b/ui/src/components/assets/AssetForm.vue
@@ -158,6 +158,7 @@ export default {
 
     save() {
       this.$validator.validateAll().then(() => {
+        console.log("validating", this.asset);
         if (!this.errors.any()) {
           this.asset.active = true;
           if (this.addMore) this.$emit("addAnother", this.asset);
@@ -168,6 +169,7 @@ export default {
     },
 
     saveAddress(resp) {
+      console.log("saving", this.asset);
       this.asset.location = resp;
       this.addressWasSaved = true;
       this.showAddressForm = false;

--- a/ui/src/components/assets/AssetForm.vue
+++ b/ui/src/components/assets/AssetForm.vue
@@ -15,6 +15,23 @@
           data-cy="description"
         ></v-textarea>
 
+        <v-btn
+          small
+          color="primary"
+          text
+          :disabled="addressWasSaved"
+          @click="changeAddressView(true)"
+        >
+        {{ $t("actions.add-address") }}
+        </v-btn>
+
+        <address-form
+          v-if="showAddressForm"
+          @cancel="changeAddressView"
+          @saved="saveAddress"
+        >
+        </address-form>
+
         <entity-search
           location
           name="location"
@@ -60,8 +77,10 @@
 <script>
 import { isEmpty } from "lodash";
 import EntitySearch from "../EntitySearch";
+import AddressForm from "../AddressForm.vue";
+
 export default {
-  components: { "entity-search": EntitySearch },
+  components: { "entity-search": EntitySearch, "address-form": AddressForm },
   name: "AssetForm",
   props: {
     editMode: {
@@ -81,6 +100,8 @@ export default {
   },
   data: function () {
     return {
+      showAddressForm: false,
+      addressWasSaved: false,
       asset: {},
       save_loading: false,
       add_more_loading: false,
@@ -112,6 +133,11 @@ export default {
     formDisabled() {
       return this.saveLoading || this.addMoreLoading;
     },
+
+    addressSaved() {
+      return this.addressWasSaved;
+    },
+
   },
 
   methods: {
@@ -121,6 +147,7 @@ export default {
 
     // Clear the form and the validators.
     clear() {
+      this.addressWasSaved = false;
       delete this.asset.location;
       for (let key of this.assetKeys) {
         this.asset[key] = "";
@@ -138,6 +165,17 @@ export default {
         }
         this.addMore = false;
       });
+    },
+
+    saveAddress(resp) {
+      this.asset.location = resp;
+      this.addressWasSaved = true;
+      this.showAddressForm = false;
+      this.save();
+    },
+
+    changeAddressView(show) {
+      this.showAddressForm = show;
     },
 
     addAnother() {

--- a/ui/src/components/assets/AssetForm.vue
+++ b/ui/src/components/assets/AssetForm.vue
@@ -36,7 +36,7 @@
           location
           name="location"
           v-model="asset.location"
-          v-validate="'required'"
+          v-validate="checkLocation"
           v-bind:error-messages="errors.first('location')"
         />
       </form>
@@ -141,6 +141,11 @@ export default {
   },
 
   methods: {
+
+    checkLocation(){
+      return this.asset.location;
+    },
+
     cancel() {
       this.$emit("cancel");
     },
@@ -163,6 +168,7 @@ export default {
           this.asset.active = true;
           if (this.addMore) this.$emit("addAnother", this.asset);
           else this.$emit("save", this.asset);
+          this.addressWasSaved = false;
         }
         this.addMore = false;
       });

--- a/ui/src/components/assets/AssetTable.vue
+++ b/ui/src/components/assets/AssetTable.vue
@@ -384,7 +384,7 @@ export default {
             this.showSnackbar(this.$t("assets.error-editing-asset"));
           });
       } else {
-        console.log(newAsset);
+        //console.log(newAsset);
         delete newAsset.event_count;
         this.$http
           .post("/api/v1/assets/?include_location=1", newAsset)

--- a/ui/src/components/courses/ClassMeetingForm.vue
+++ b/ui/src/components/courses/ClassMeetingForm.vue
@@ -121,6 +121,23 @@
           data-cy="course-offering-teacher"
         />
 
+        <address-form
+          v-if="showAddressForm"
+          @cancel="changeAddressView"
+          @saved="saveAddress"
+        >
+        </address-form>
+
+        <v-btn
+          small
+          color="primary"
+          text
+          :disabled="addressWasSaved"
+          @click="changeAddressView(true)"
+        >
+        {{ $t("actions.add-address") }}
+        </v-btn>
+
         <!-- location -->
         <EntitySearch
           location
@@ -160,6 +177,7 @@
 
 <script>
 import { isEmpty, clone, cloneDeep } from "lodash";
+import AddressForm from "../AddressForm.vue";
 import EntitySearch from "../EntitySearch";
 import { mapGetters } from "vuex";
 
@@ -168,12 +186,16 @@ export default {
 
   components: {
     EntitySearch,
+    "address-form": AddressForm
   },
 
   data() {
     return {
       saving: false,
       savingProgress: 0,
+
+      showAddressForm: false,
+      addressWasSaved: false,
 
       classMeeting: {},
       dates: "",
@@ -201,6 +223,11 @@ export default {
       return this.getDateFromTimestamp(Date.now());
     },
     ...mapGetters(["currentLanguageCode"]),
+
+    addressSaved() {
+      return this.addressWasSaved;
+    },
+
   },
 
   watch: {
@@ -244,11 +271,28 @@ export default {
 
     // Clear the forms.
     clear() {
+      this.addressWasSaved = false;
       this.dates = this.editMode ? "" : [];
       this.time = "";
       this.teacher = {};
       this.location = {};
       this.$validator.reset();
+    },
+
+    checkLocation(){
+      return this.location;
+    },
+
+    saveAddress(resp) {
+      console.log("saving", this.asset);
+      this.asset.location = resp;
+      this.addressWasSaved = true;
+      this.showAddressForm = false;
+      this.save();
+    },
+
+    changeAddressView(show) {
+      this.showAddressForm = show;
     },
 
     save() {

--- a/ui/src/components/courses/ClassMeetingForm.vue
+++ b/ui/src/components/courses/ClassMeetingForm.vue
@@ -301,6 +301,7 @@ export default {
           this.saving = true;
           let classMeeting = cloneDeep(this.classMeeting);
           this.saveClassMeeting(classMeeting);
+          
         }
       });
     },
@@ -323,6 +324,7 @@ export default {
             newMeeting.location = this.location;
             newMeeting.teacher = this.teacher;
             this.$emit("save", [newMeeting]); // Parent expects array of updated records
+            this.addressWasSaved = false;
           })
           .catch((err) => {
             this.$emit("save", err);
@@ -368,6 +370,7 @@ export default {
         Promise.all(promises)
           .then((newMeetings) => {
             this.$emit("save", newMeetings);
+            this.addressWasSaved = false;
           })
           .catch((err) => {
             this.$emit("save", err);

--- a/ui/src/components/people/ActionIconButton.vue
+++ b/ui/src/components/people/ActionIconButton.vue
@@ -3,7 +3,7 @@
     <template v-slot:activator="{ on }">
       <v-btn
         icon
-        outline
+        outlined
         small
         color="primary"
         v-on="on"

--- a/ui/src/components/people/PersonForm.vue
+++ b/ui/src/components/people/PersonForm.vue
@@ -596,8 +596,22 @@ export default {
           delete this.person["attributesInfo"];
           delete this.person["accountInfo"];
           delete this.person["id"];
+          let id = this.person.id;
+          let active = this.person.active;
+          let firstName = this.person.firstName;
+          let lastName = this.person.lastName;
+          let secondLastName = this.person.secondLastName;
+          let gender = this.person.gender;
+          let birthday = this.person.birthday;
+          let email = this.person.email;
+          let username = this.person.username;
+          let password = this.person.password;
+          let phone = this.person.phone;
+          let addressId = this.person.addressId;
+          let personObject = { id, active, firstName, lastName, secondLastName, 
+          gender, birthday, email, username, password, phone, addressId };
           let data = {
-            person: this.person,
+            person: personObject,
             attributesInfo: attributes,
           };
           if (personId) {
@@ -696,25 +710,9 @@ export default {
             });
         } else {
           console.log("editing", data);
-          let id = data.person.id;
-          let active = data.person.active;
-          let firstName = data.person.firstName;
-          let lastName = data.person.lastName;
-          let secondLastName = data.person.secondLastName;
-          let gender = data.person.gender;
-          let birthday = data.person.birthday;
-          let email = data.person.email;
-          let username = data.person.username;
-          let password = data.person.password;
-          let phone = data.person.phone;
-          let addressId = data.person.addressId;
-          let attributesInfo = data.attributesInfo;
-          let person = { id, active, firstName, lastName, secondLastName, 
-          gender, birthday, email, username, password, phone, addressId };
-          let box = {attributesInfo, person};
           // an image didn't happen (NOTHING)
           this.$http
-            .put(`/api/v1/people/persons/${personId}`, box)
+            .put(`/api/v1/people/persons/${personId}`, data)
             .then((response) => {
               
               this.$emit(emitMessage, response.data);
@@ -735,24 +733,8 @@ export default {
         imageId = this.person.newImageId;
       }
       delete this.person.newImageId;
-      let id = data.person.id;
-      let active = data.person.active;
-      let firstName = data.person.firstName;
-      let lastName = data.person.lastName;
-      let secondLastName = data.person.secondLastName;
-      let gender = data.person.gender;
-      let birthday = data.person.birthday;
-      let email = data.person.email;
-      let username = data.person.username;
-      let password = data.person.password;
-      let phone = data.person.phone;
-      let addressId = data.person.addressId;
-      let attributesInfo = data.attributesInfo;
-      let person = { id, active, firstName, lastName, secondLastName, 
-      gender, birthday, email, username, password, phone, addressId };
-      let box = {attributesInfo, person};
       this.$http
-        .post("/api/v1/people/persons", box)
+        .post("/api/v1/people/persons", data)
         .then(async (response) => {
           if (imageId > -1) {
             await this.addImage(response.data.id, imageId);

--- a/ui/src/components/people/PersonForm.vue
+++ b/ui/src/components/people/PersonForm.vue
@@ -191,6 +191,10 @@
             ref="attributeForm"
           />
           <v-layout row justify-center align-space-around>
+            <v-card v-if='person.address'>
+              <v-card-text> {{ $t(person.address.name) }}</v-card-text>
+              <v-card-text> {{ $t(person.address.address) }}</v-card-text>
+            </v-card>
             <v-flex shrink>
               <v-btn
                 small
@@ -524,6 +528,7 @@ export default {
       this.saveIsLoading = false;
       this.addMoreIsLoading = false;
       this.currentStep = 1;
+      this.addressWasSaved = false;
     },
 
     addMore() {
@@ -691,10 +696,25 @@ export default {
             });
         } else {
           console.log("editing", data);
-
+          let id = data.person.id;
+          let active = data.person.active;
+          let firstName = data.person.firstName;
+          let lastName = data.person.lastName;
+          let secondLastName = data.person.secondLastName;
+          let gender = data.person.gender;
+          let birthday = data.person.birthday;
+          let email = data.person.email;
+          let username = data.person.username;
+          let password = data.person.password;
+          let phone = data.person.phone;
+          let addressId = data.person.addressId;
+          let attributesInfo = data.attributesInfo;
+          let person = { id, active, firstName, lastName, secondLastName, 
+          gender, birthday, email, username, password, phone, addressId };
+          let box = {attributesInfo, person};
           // an image didn't happen (NOTHING)
           this.$http
-            .put(`/api/v1/people/persons/${personId}`, data)
+            .put(`/api/v1/people/persons/${personId}`, box)
             .then((response) => {
               
               this.$emit(emitMessage, response.data);
@@ -715,9 +735,24 @@ export default {
         imageId = this.person.newImageId;
       }
       delete this.person.newImageId;
-      console.log("Adding", data);
+      let id = data.person.id;
+      let active = data.person.active;
+      let firstName = data.person.firstName;
+      let lastName = data.person.lastName;
+      let secondLastName = data.person.secondLastName;
+      let gender = data.person.gender;
+      let birthday = data.person.birthday;
+      let email = data.person.email;
+      let username = data.person.username;
+      let password = data.person.password;
+      let phone = data.person.phone;
+      let addressId = data.person.addressId;
+      let attributesInfo = data.attributesInfo;
+      let person = { id, active, firstName, lastName, secondLastName, 
+      gender, birthday, email, username, password, phone, addressId };
+      let box = {attributesInfo, person};
       this.$http
-        .post("/api/v1/people/persons", data)
+        .post("/api/v1/people/persons", box)
         .then(async (response) => {
           if (imageId > -1) {
             await this.addImage(response.data.id, imageId);

--- a/ui/src/components/people/PersonForm.vue
+++ b/ui/src/components/people/PersonForm.vue
@@ -609,6 +609,7 @@ export default {
     },
 
     async updatePerson(data, personId, emitMessage) {
+      console.log("What I'm Saying", emitMessage);
       let newImageId = null;
       if (this.person.newImageId) {
         newImageId = this.person.newImageId;
@@ -689,10 +690,13 @@ export default {
               console.error("ERROR DELETING IMAGE", err.response);
             });
         } else {
+          console.log("editing", data);
+
           // an image didn't happen (NOTHING)
           this.$http
             .put(`/api/v1/people/persons/${personId}`, data)
             .then((response) => {
+              
               this.$emit(emitMessage, response.data);
               this.resetForm();
               this.saveIsLoading = false;
@@ -711,6 +715,7 @@ export default {
         imageId = this.person.newImageId;
       }
       delete this.person.newImageId;
+      console.log("Adding", data);
       this.$http
         .post("/api/v1/people/persons", data)
         .then(async (response) => {

--- a/ui/src/components/people/PersonForm.vue
+++ b/ui/src/components/people/PersonForm.vue
@@ -726,6 +726,8 @@ export default {
             this.$emit(emitMessage, response.data);
             this.resetForm();
           }
+          console.log("response");
+          console.log(response.data);
           this.$emit("attachPerson", response.data);
         })
         .catch((err) => {

--- a/ui/src/pages/People.vue
+++ b/ui/src/pages/People.vue
@@ -56,6 +56,8 @@ export default {
       this.$http
         .get("/api/v1/people/persons?include_images=1")
         .then((resp) => {
+          console.log("GET");
+          console.log(resp.data);
           this.peopleList = resp.data;
           this.tableLoaded = true;
         })


### PR DESCRIPTION
-Added ability to create a new address and link it directly to either a person, group meeting, class meeting, or asset when creating one of those
-Added displayed address information while editing a person
-Note: because the class meeting page/form is not accessible through the browser I was unable to test that functionality, but it should be close to being working and will only need a few tests to fix anything  